### PR TITLE
Fix broken selfSignature since the switch to ProtonMail lib

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -43,22 +43,24 @@ func SSHPrivateKeyToPGP(sshPrivateKey []byte, name string, comment string, email
 	}
 	uid := packet.NewUserId(name, comment, email)
 	isPrimaryID := true
+	selfSignature := &packet.Signature{
+		CreationTime:              timeNull,
+		SigType:                   packet.SigTypePositiveCert,
+		PubKeyAlgo:                packet.PubKeyAlgoRSA,
+		Hash:                      crypto.SHA256,
+		IsPrimaryId:               &isPrimaryID,
+		FlagsValid:                true,
+		FlagSign:                  true,
+		FlagCertify:               true,
+		FlagEncryptStorage:        true,
+		FlagEncryptCommunications: true,
+		IssuerKeyId:               &gpgKey.PrimaryKey.KeyId,
+	}
 	gpgKey.Identities[uid.Id] = &openpgp.Identity{
 		Name:   uid.Id,
 		UserId: uid,
-		SelfSignature: &packet.Signature{
-			CreationTime:              timeNull,
-			SigType:                   packet.SigTypePositiveCert,
-			PubKeyAlgo:                packet.PubKeyAlgoRSA,
-			Hash:                      crypto.SHA256,
-			IsPrimaryId:               &isPrimaryID,
-			FlagsValid:                true,
-			FlagSign:                  true,
-			FlagCertify:               true,
-			FlagEncryptStorage:        true,
-			FlagEncryptCommunications: true,
-			IssuerKeyId:               &gpgKey.PrimaryKey.KeyId,
-		},
+		SelfSignature: selfSignature,
+		Signatures: []*packet.Signature{selfSignature},
 	}
 	err = gpgKey.Identities[uid.Id].SelfSignature.SignUserId(uid.Id, gpgKey.PrimaryKey, gpgKey.PrivateKey, nil)
 	if err != nil {

--- a/convert.go
+++ b/convert.go
@@ -57,10 +57,10 @@ func SSHPrivateKeyToPGP(sshPrivateKey []byte, name string, comment string, email
 		IssuerKeyId:               &gpgKey.PrimaryKey.KeyId,
 	}
 	gpgKey.Identities[uid.Id] = &openpgp.Identity{
-		Name:   uid.Id,
-		UserId: uid,
+		Name:          uid.Id,
+		UserId:        uid,
 		SelfSignature: selfSignature,
-		Signatures: []*packet.Signature{selfSignature},
+		Signatures:    []*packet.Signature{selfSignature},
 	}
 	err = gpgKey.Identities[uid.Id].SelfSignature.SignUserId(uid.Id, gpgKey.PrimaryKey, gpgKey.PrivateKey, nil)
 	if err != nil {


### PR DESCRIPTION
Fixes #73

It seems like the selfSignature needs to be explicitly added in the array all the signatures.
Maybe this was done implicitly with the previous lib...

Anyway, with this fix, I'm now able to properly import the key as in <= 1.1.2.
