### PR TITLE
Add a test to import the converted key

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -52,7 +52,7 @@ func TestCli(t *testing.T) {
 	}
 	for _, cmd := range cmds {
 		// Make sure we clean the states between each command
-		exec.Command("rm", "-rf", gpgHome + "/*")
+		exec.Command("rm", "-rf", gpgHome+"/*")
 		err = convertKeys(cmd)
 		ok(t, err)
 		cmd := exec.Command("gpg", "--with-fingerprint", "--show-key", out)


### PR DESCRIPTION
Refers to #73
Depends on #98

This PR verifies that we can import the converted key(s).
Checks should fail on on top of the current HEAD (990d41a), but should succeed on top of #98.