### PR TITLE
Revert "update-flake-inputs: fix shallow git clones"

### DIFF
--- a/.github/workflows/update-flake-inputs.yml
+++ b/.github/workflows/update-flake-inputs.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Nix
         uses: cachix/install-nix-action@v31
       - name: Update flake inputs
-        uses: mic92/update-flake-inputs@fix-update
+        uses: mic92/update-flake-inputs@main
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           auto-merge: true


### PR DESCRIPTION

This reverts commit d703004d64d04efb1c411d96e088dc02af0a7e0a.

No longer needed, fixed in main.
